### PR TITLE
Fix `stringsloader` module appears in the project tree

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 27
 
     defaultConfig {
-        applicationId "com.romanwuattier.stringsloader"
+        applicationId "com.romanwuattier.loader"
         minSdkVersion 16
         targetSdkVersion 27
         versionCode 1

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':stringsloader', ':loader'
+include ':app', ':loader'


### PR DESCRIPTION
Delete `stringsloader` from settings.gradle and applicationId

Close: #11